### PR TITLE
feat(commands): add ignore-scripts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ gulp.task('yarn', function() {
 | noBinLinks    | None of `node_module` bin links getting created.                                                                                                                       | Boolean |
 | noProgress    | Disable progress bar                                                                                                                                                   | Boolean |
 | noLockfile    | Don't read or generate a lockfile                                                                                                                                      | Boolean |
+| ignoreScripts | Don't run npm scripts during installation                                                                                                                              | Boolean |
 
 ## Test
 ```sh

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -10,5 +10,6 @@ module.exports = {
     noBinLinks: '--no-bin-links',
     ignoreEngines: '--ignore-engines',
     noProgress: '--no-progress',
-    noLockfile: "--no-lockfile"
+    noLockfile: '--no-lockfile',
+    ignoreScripts: '--ignore-scripts'
 };

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -235,6 +235,31 @@ describe('gulp-yarn', function () {
             stream.end();
         });
 
+    it('should run `yarn --ignore-scripts` if stream contains `package.json` and `ignoreScripts` option is set', function (done) {
+        var file = fixture('package.json');
+
+        var stream = yarn({ignoreScripts: true});
+
+        stream.on('error', function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on('data', function () {
+        });
+
+        stream.on('end', function () {
+            commandRunner.run.called.should.equal(1);
+            commandRunner.run.commands[0].cmd.should.equal('yarn');
+            commandRunner.run.commands[0].args.should.eql(['--ignore-scripts']);
+            done();
+        });
+
+        stream.write(file);
+
+        stream.end();
+    });
+
     it('should run `yarn --no-progress` to disable progress bar', function (done) {
         var file = fixture('package.json');
 


### PR DESCRIPTION
This is related to #3 but doesn't close it. I needed the `--ignore-scripts` option in my project. Ideally `gulp-yarn` should support any argument but supporting that securely may be tricky. In the meantime this PR adds the feature I needed.