### PR TITLE
Support of yarn non-interaction command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ gulp.task('yarn', function() {
 | noProgress    | Disable progress bar                                                                                                                                                   | Boolean |
 | noLockfile    | Don't read or generate a lockfile                                                                                                                                      | Boolean |
 | ignoreScripts | Don't run npm scripts during installation                                                                                                                              | Boolean |
+| nonInteractive| Using the '--non-interactive' flag of yarn to avoid that during the resolution (yarn install) a user input is needed. [2770](https://github.com/yarnpkg/yarn/pull/2770)| Boolean | 
 
 ## Test
 ```sh

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -11,5 +11,6 @@ export default {
 	ignoreEngines: '--ignore-engines',
 	noProgress: '--no-progress',
 	noLockfile: '--no-lockfile',
-	ignoreScripts: '--ignore-scripts'
+	ignoreScripts: '--ignore-scripts',
+	nonInteractive: '--non-interactive'
 };


### PR DESCRIPTION
Adding yarn non-interaction command to avoid the resolution of versions (when for example buildserver is building)

can be set by 
`.pipe(yarn({nonInteractive: true}))`