### PR TITLE
Wait for Yarn install to complete

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4
+


### PR DESCRIPTION
[Trough2’s flush function isn’t awaited](https://github.com/rvagg/through2/issues/60), which means that the Yarn
install was running outside of the Gulp stream

I also added an `.editorconfig` to make supported editors use 4 spaces.