### PR TITLE
fix(core): Allow Windows paths containing a white-space

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function gulpYarn(gulpYarnOptions) {
                         shell: true,
                         cwd: singleCommand.cwd || process.cwd()
                     };
-                    var cmd = childProcess.spawn(cmdpath, singleCommand.args, installOptions);
+                    var cmd = childProcess.spawn(`"${cmdpath}"`, singleCommand.args, installOptions);
                     cmd.once('close', function (code) {
                         if (code !== 0) {
                             next(new PluginError(PLUGIN_NAME, `${command.cmd} exited with non-zero code ${code}.`));


### PR DESCRIPTION
If you install Yarn through the msi installer, it will install itself under `C:/Program Files/` however, gulp-yarn does not escape white-spaces in the path, which causes errors such as:

`'C:\Program' is not recognized as an internal or external command,
operable program or batch file.`

This PR, will add quotes around the filepath so that windows will not throw the error.

Tested:
Windows 10
Yarn 1.3.2
Node 9.4.0