### PR TITLE
Add support for specifying yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ gulp.task('yarn', function() {
 | ignoreScripts | Don't run npm scripts during installation                                                                                                                              | Boolean |
 | nonInteractive| Using the '--non-interactive' flag of yarn to avoid that during the resolution (yarn install) a user input is needed. [2770](https://github.com/yarnpkg/yarn/pull/2770)| Boolean | 
 | args          | Pass any argument with `--` to execute with yarn                                                                                                                       | String/Array |
+| cmd           | Yarn command to run (e.g. check, add)                                                                                                                                  | String |
 
 ## Test
 ```sh

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,7 @@ describe('gulpYarn', function () {
 
             // check child process calls
             expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql([ '--production' ]);
             done();
         });
 
@@ -127,6 +128,7 @@ describe('gulpYarn', function () {
 
             // check child process calls
             expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql([]);
             done();
         });
 
@@ -177,6 +179,7 @@ describe('gulpYarn', function () {
 
             // check child process calls
             expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql(['--production', '--no-bin-links']);
             done();
         });
 
@@ -204,6 +207,64 @@ describe('gulpYarn', function () {
 
             // check child process calls
             expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql([ '--production --no-bin-links' ]);
+            done();
+        });
+
+        // write the fake file to it
+        gulpYarnObject.write(fakeFile);
+    });
+
+    it(`should run with yarn command`, function(done) {
+        // create the fake file
+        var fakeFile = new File({
+            base: "package",
+            path: "test/package.json",
+            contents: new Buffer(JSON.stringify(pkg))
+        });
+
+        // Create a gulpYarn plugin stream
+        var gulpYarnObject = gulpYarn({
+            cmd: 'check'
+        });
+
+        // wait for the file to come back out
+        gulpYarnObject.once('data', function (file) {
+            // make sure it came out the same way it went in
+            should.exist(file.isBuffer());
+
+            // check child process calls
+            expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql([ 'check' ]);
+            done();
+        });
+
+        // write the fake file to it
+        gulpYarnObject.write(fakeFile);
+    });
+
+    it(`should run with yarn command and args`, function(done) {
+        // create the fake file
+        var fakeFile = new File({
+            base: "package",
+            path: "test/package.json",
+            contents: new Buffer(JSON.stringify(pkg))
+        });
+
+        // Create a gulpYarn plugin stream
+        var gulpYarnObject = gulpYarn({
+            cmd: 'check',
+            args: [ '--production', '--no-bin-links' ]
+        });
+
+        // wait for the file to come back out
+        gulpYarnObject.once('data', function (file) {
+            // make sure it came out the same way it went in
+            should.exist(file.isBuffer());
+
+            // check child process calls
+            expect(sandbox.calls.length).to.be.equal(1);
+            expect(sandbox.calls[0].args).to.eql([ 'check', '--production', '--no-bin-links' ]);
             done();
         });
 


### PR DESCRIPTION
This PR add support for specifying a yarn command (i.e. without a `--` prefix, such as `yarn check`).  With the current version, the only way to do this is to use the args with a unnecessary option before it, e.g. `args: '--no-progress check'.

I've also updated the existing unit tests to check that the arguments were being correctly processed, as they were simply checking that spawn was being called.